### PR TITLE
MIssing install section

### DIFF
--- a/deploy/firewall.service
+++ b/deploy/firewall.service
@@ -12,3 +12,5 @@ RemainAfterExit=yes
 ExecStart=/usr/libexec/firewall/exec-start.sh
 ExecStop=/usr/libexec/firewall/exec-stop.sh
 
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
The install section is needed to allow the fw to set up its own rules after a reboot. Otherwise, it won't.
